### PR TITLE
validator: make example to carry v1beta1 version

### DIFF
--- a/examples/valid-populator.yaml
+++ b/examples/valid-populator.yaml
@@ -1,5 +1,5 @@
 kind: VolumePopulator
-apiVersion: populator.storage.k8s.io/v1alpha1
+apiVersion: populator.storage.k8s.io/v1beta1
 metadata:
   name: valid-populator
 sourceKind:


### PR DESCRIPTION
As the controller API has been moved from alpha1 to beta1
the examples also has to follow

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


> /kind bug


```release-note
NONE
```
