### PR TITLE
Fix CRD definition to be cluster-scoped

### DIFF
--- a/client/apis/volumepopulator/v1beta1/types.go
+++ b/client/apis/volumepopulator/v1beta1/types.go
@@ -24,7 +24,11 @@ import (
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// VolumePopulator represents the registration for a volume populator
+// VolumePopulator represents the registration for a volume populator.
+// VolumePopulators are cluster scoped.
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:printcolumn:name="SourceKind",type=string,JSONPath=`.sourceKind`
 type VolumePopulator struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -38,6 +42,7 @@ type VolumePopulator struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // VolumePopulatorList is a list of VolumePopulator objects
+// +kubebuilder:object:root=true
 type VolumePopulatorList struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional

--- a/client/config/crd/populator.storage.k8s.io_volumepopulators.yaml
+++ b/client/config/crd/populator.storage.k8s.io_volumepopulators.yaml
@@ -15,12 +15,16 @@ spec:
     listKind: VolumePopulatorList
     plural: volumepopulators
     singular: volumepopulator
-  scope: Namespaced
+  scope: Cluster
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .sourceKind
+      name: SourceKind
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
-        description: VolumePopulator represents the registration for a volume populator
+        description: VolumePopulator represents the registration for a volume populator. VolumePopulators are cluster scoped.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -46,6 +50,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/vendor/github.com/kubernetes-csi/volume-data-source-validator/client/apis/volumepopulator/v1beta1/types.go
+++ b/vendor/github.com/kubernetes-csi/volume-data-source-validator/client/apis/volumepopulator/v1beta1/types.go
@@ -24,7 +24,11 @@ import (
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// VolumePopulator represents the registration for a volume populator
+// VolumePopulator represents the registration for a volume populator.
+// VolumePopulators are cluster scoped.
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:printcolumn:name="SourceKind",type=string,JSONPath=`.sourceKind`
 type VolumePopulator struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -38,6 +42,7 @@ type VolumePopulator struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // VolumePopulatorList is a list of VolumePopulator objects
+// +kubebuilder:object:root=true
 type VolumePopulatorList struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix bug which makes the CRD namespaced when it should be cluster scoped.

**Which issue(s) this PR fixes**:
Fixes #23

**Does this PR introduce a user-facing change?**:
```release-note
The yaml for the CRD now correctly installs VolumePopulator as a cluster-scoped object.
```
