### PR TITLE
Expose metrics on port 8080

### DIFF
--- a/cmd/volume-data-source-validator/main.go
+++ b/cmd/volume-data-source-validator/main.go
@@ -57,7 +57,7 @@ var (
 	leaderElectionRenewDeadline = flag.Duration("leader-election-renew-deadline", 10*time.Second, "Duration, in seconds, that the acting leader will retry refreshing leadership before giving up. Defaults to 10 seconds.")
 	leaderElectionRetryPeriod   = flag.Duration("leader-election-retry-period", 5*time.Second, "Duration, in seconds, the LeaderElector clients should wait between tries of actions. Defaults to 5 seconds.")
 
-	httpEndpoint = flag.String("http-endpoint", "", "The TCP network address where the HTTP server for diagnostics, including metrics and leader election health check, will listen (example: `:8080`). The default is empty string, which means the server is disabled. Only one of `--metrics-address` and `--http-endpoint` can be set.")
+	httpEndpoint = flag.String("http-endpoint", "", "The TCP network address where the HTTP server for diagnostics, including metrics and leader election health check, will listen (example: `:8080`). The default is empty string, which means the server is disabled.")
 	metricsPath  = flag.String("metrics-path", "/metrics", "The HTTP path where prometheus metrics will be exposed. Default is `/metrics`.")
 )
 

--- a/deploy/kubernetes/setup-data-source-validator.yaml
+++ b/deploy/kubernetes/setup-data-source-validator.yaml
@@ -30,4 +30,9 @@ spec:
           args:
             - "--v=5"
             - "--leader-election=false"
+            - "--http-endpoint=:8080"
           imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+              name: http-endpoint
+              protocol: TCP


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Expose metrics on port 8080
Also fix help message for http-endpoint

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
By default, metrics are now exposed on port 8080.
```