### PR TITLE
Update volume-data-source-validator yaml to use published v0.1.0 image

### DIFF
--- a/deploy/kubernetes/setup-data-source-validator.yaml
+++ b/deploy/kubernetes/setup-data-source-validator.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccount: volume-data-source-validator
       containers:
         - name: volume-data-source-validator
-          image: volume-data-source-validator:latest
+          image: k8s.gcr.io/sig-storage/volume-data-source-validator:v0.1.0
           args:
             - "--v=5"
             - "--leader-election=false"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
For users to test steps described in https://kubernetes.io/blog/2021/08/30/volume-populators-redesigned/#putting-it-all-together , published image should be used for volume-data-source-validator.

**Which issue(s) this PR fixes**:
Fixes #22 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
