### PR TITLE
Remove unneeded metadata from CRD

### DIFF
--- a/client/config/crd/populator.storage.k8s.io_volumepopulators.yaml
+++ b/client/config/crd/populator.storage.k8s.io_volumepopulators.yaml
@@ -32,8 +32,6 @@ spec:
           kind:
             description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
-          metadata:
-            type: object
           sourceKind:
             description: Kind of the data source this populator supports
             properties:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix the CRD to remove a junk auto-generated field

**Which issue(s) this PR fixes**:
Fixes #30

**Does this PR introduce a user-facing change?**:
```release-note
VolumePopulator CRD was updated to remove junk auto-generated field
```
