### PR TITLE
Replace k8s.gcr.io  with registry.k8s.io

### DIFF
--- a/deploy/kubernetes/setup-data-source-validator.yaml
+++ b/deploy/kubernetes/setup-data-source-validator.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccount: volume-data-source-validator
       containers:
         - name: volume-data-source-validator
-          image: k8s.gcr.io/sig-storage/volume-data-source-validator:v1.0.0
+          image: registry.k8s.io/sig-storage/volume-data-source-validator:v1.0.0
           args:
             - "--v=5"
             - "--leader-election=false"


### PR DESCRIPTION
Refer# https://github.com/kubernetes/k8s.io/wiki/New-Registry-url-for-Kubernetes-(registry.k8s.io)

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

> /kind cleanup

```release-note
NONE
```
