### PR TITLE
deploy: update volume-data-source-validator image version

### DIFF
--- a/deploy/kubernetes/setup-data-source-validator.yaml
+++ b/deploy/kubernetes/setup-data-source-validator.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccount: volume-data-source-validator
       containers:
         - name: volume-data-source-validator
-          image: registry.k8s.io/sig-storage/volume-data-source-validator:v1.6.0
+          image: registry.k8s.io/sig-storage/volume-data-source-validator:v1.7.0
           args:
             - "--v=5"
             - "--leader-election=false"


### PR DESCRIPTION
Update the `volume-data-source-validator` image reference in `deploy/kubernetes/setup-data-source-validator.yaml` to the latest stable release.

## Changes

- `volume-data-source-validator`: v1.6.0 → v1.7.0